### PR TITLE
Bugfix/blueprint state

### DIFF
--- a/nevojs-core/src/individual/blueprint/blueprint.ts
+++ b/nevojs-core/src/individual/blueprint/blueprint.ts
@@ -29,7 +29,7 @@ import { Resolved } from "../../util";
  */
 export interface BlueprintCreationSettings<G extends Genotype | Promise<Genotype>, P> extends BlueprintConstructorSettings<G, P> {
   arg: () => any;
-  state: () => any;
+  state: () => State;
 }
 
 /**
@@ -88,7 +88,9 @@ export class Blueprint<G extends Genotype | Promise<Genotype>, P> extends Indivi
     }
 
     const phenotype = settings.phenotype ?? this.phenotypeFunc;
-    const state = settings.state;
+    const state: State | undefined = settings.state
+      ? settings.state()
+      : undefined;
 
     const individual = new Individual({
       genotype: genotype as Resolved<G>,

--- a/nevojs-core/src/individual/data.ts
+++ b/nevojs-core/src/individual/data.ts
@@ -39,5 +39,7 @@ export type GenotypeData<G extends Genotype> = G extends Genotype<infer D> ? D :
  *
  */
 export type State = {
+  apply?: void;
+  call?: void;
   [key: string]: any;
 };


### PR DESCRIPTION
Updates `State` type to be no longer compatible with functions and makes state being properly created in blueprint creation methods.